### PR TITLE
PCI: brcmstb: Wait for 100ms following PERST# deassert

### DIFF
--- a/drivers/pci/controller/pcie-brcmstb.c
+++ b/drivers/pci/controller/pcie-brcmstb.c
@@ -1038,8 +1038,15 @@ static int brcm_pcie_start_link(struct brcm_pcie *pcie)
 	pcie->perst_set(pcie, 0);
 
 	/*
-	 * Give the RC/EP time to wake up, before trying to configure RC.
-	 * Intermittently check status for link-up, up to a total of 100ms.
+	 * Wait for 100ms after PERST# deassertion; see PCIe CEM specification
+	 * sections 2.2, PCIe r5.0, 6.6.1.
+	 */
+	msleep(100);
+
+	/*
+	 * Give the RC/EP even more time to wake up, before trying to
+	 * configure RC.  Intermittently check status for link-up, up to a
+	 * total of 100ms.
 	 */
 	for (i = 0; i < 100 && !brcm_pcie_link_up(pcie); i += 5)
 		msleep(5);


### PR DESCRIPTION
commit 3ae140ad827b359bc4fa7c7985691c4c1e3ca8f4 upstream.

Be prudent and give some time for power and clocks to become stable.  As described in the PCIe CEM specification sections 2.2 and 2.2.1; as well as PCIe r5.0, 6.6.1.

Link: https://lore.kernel.org/r/20221011184211.18128-3-jim2101024@gmail.com


Acked-by: Florian Fainelli <f.fainelli@gmail.com>